### PR TITLE
[docker] Docker support

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,0 +1,29 @@
+# Basic docker image for leek-wars-client
+#
+# Usage:
+#   docker build -t leek-wars-client .
+#   docker run --rm -p 8012:8012 -P leek-wars-client
+#
+#   or
+#
+#   docker build -t leek-wars-client .
+#   docker run --rm -p 8012:8012 -v /path/to/local/app/folder:/app -it -P leek-wars-client /bin/sh
+
+FROM alpine:3.4
+MAINTAINER Pierre Lauprêtre <https://github.com/5pilow>
+
+# Default port the webserver runs on
+EXPOSE 8012
+
+# Working directory for the application
+WORKDIR /app/
+
+# Install required packages
+RUN apk add --no-cache python3
+
+# Copy everything to the working directory
+ADD leekwars.py leekwars.py
+ADD http/ http/
+
+# Run the application
+ENTRYPOINT ["python3", "leekwars.py"]


### PR DESCRIPTION
Support pour Docker

**En production :** 
```
docker build -t leek-wars-client .
docker run --rm -p 8012:8012 -P leek-wars-client

+ reverse proxy vers le port 8012
  ou http://ip:8012/
```
Attention: Ne print pas de logs

**En dev :**
```
docker build -t leek-wars-client .
docker run --rm -p 8012:8012 -v /path/to/local/app/folder:/app -it -P leek-wars-client /bin/sh

+ http://localhost:8012/
```
Applique les changements en live dans le container
Print les logs du script python
Attention: Il écoute sur 0.0.0.0 et pas en local par défaut

![image](https://cloud.githubusercontent.com/assets/12863317/18895919/7df21c98-851d-11e6-8900-78671a68b07c.png)

Testé sous **Windows 10 Pro** avec **Docker for windows**