### PR TITLE
Amélioration du scroll dans les chats (#5)

### DIFF
--- a/http/script/main.js
+++ b/http/script/main.js
@@ -3601,6 +3601,14 @@ var ChatController = function(chat_element, private_chat, team_chat) {
 
 		var completeDate = _.lang.get('forum', 'chat_the_mdy_at_hm', date.getDate(), date.getMonth() + 1, date.getFullYear(), date.getHours(), minuts);
 
+		// Scroll
+		var scrollAction = false
+		if (this.msg_elem.length > 0) {
+			if (this.msg_elem[0].scrollHeight - this.msg_elem.scrollTop() - this.msg_elem.height() < 100) {
+				scrollAction = true
+			}
+		}
+
 		// Dernier message envoyé par la meme personne, y'a moins de 2 minutes ?
 		var last = null;
 		var messages = this.msg_elem.find('.chat-message');
@@ -3680,16 +3688,13 @@ var ChatController = function(chat_element, private_chat, team_chat) {
 			})
 		}
 
-		if (this.msg_elem.length > 0) {
+		if (scrollAction) {
+			var e = this.msg_elem
 
-			if (this.msg_elem[0].scrollHeight - this.msg_elem.scrollTop() - this.msg_elem.height() < 100) {
-				var e = this.msg_elem
-
-				// FIXME dirty but seems working
-				setTimeout(function() {
-					e.scrollTop(e[0].scrollHeight + 1000);
-				}, 60)
-			}
+			// FIXME dirty but seems working
+			setTimeout(function() {
+				e.scrollTop(e[0].scrollHeight + 1000);
+			}, 60)
 		}
 
 		if (LW.chat.channels.length == 1) {

--- a/http/script/main.js
+++ b/http/script/main.js
@@ -3490,6 +3490,18 @@ var ChatController = function(chat_element, private_chat, team_chat) {
 		hideFlags()
 	}
 
+	$(this.msg_elem).scroll(function() {
+		if ($(this).scrollTop() + $(this).height() > $(this)[0].scrollHeight - 100) {
+			controller.msg_elem.removeClass('new-messages')
+		}
+	})
+
+	chat_element.find('.chat-new-messages').click(function() {
+		$(controller.msg_elem).animate({
+			scrollTop: $(controller.msg_elem)[0].scrollHeight + 1000
+		}, 300);
+	})
+
 	if (!private_chat) {
 
 		chat_element.find('.chat-send').click(function() {
@@ -3691,10 +3703,14 @@ var ChatController = function(chat_element, private_chat, team_chat) {
 		if (scrollAction) {
 			var e = this.msg_elem
 
+			this.msg_elem.removeClass('new-messages')
+
 			// FIXME dirty but seems working
 			setTimeout(function() {
 				e.scrollTop(e[0].scrollHeight + 1000);
 			}, 60)
+		} else {
+			this.msg_elem.addClass('new-messages')
 		}
 
 		if (LW.chat.channels.length == 1) {

--- a/http/style/chat.css
+++ b/http/style/chat.css
@@ -13,22 +13,6 @@
 	margin-top: 150px;
 }
 
-.chat-new-messages {
-	display: none;
-	height: 30px;
-	line-height: 30px;
-	background-color: #bbb;
-	text-align: center;
-}
-
-.chat-new-messages:hover {
-	cursor: pointer;
-}
-
-.chat-messages.new-messages + .chat-new-messages {
-	display: block;
-}
-
 .chat-input {
 	margin-top: 10px;
 	width: 100%;

--- a/http/style/chat.css
+++ b/http/style/chat.css
@@ -13,6 +13,22 @@
 	margin-top: 150px;
 }
 
+.chat-new-messages {
+	display: none;
+	height: 30px;
+	line-height: 30px;
+	background-color: #bbb;
+	text-align: center;
+}
+
+.chat-new-messages:hover {
+	cursor: pointer;
+}
+
+.chat-messages.new-messages + .chat-new-messages {
+	display: block;
+}
+
 .chat-input {
 	margin-top: 10px;
 	width: 100%;

--- a/http/style/main.css
+++ b/http/style/main.css
@@ -651,6 +651,22 @@ body.social-collapsed #social-button .icon {
 	width: 100%;
 }
 
+.chat-new-messages {
+	display: none;
+	height: 30px;
+	line-height: 30px;
+	background-color: #bbb;
+	text-align: center;
+}
+
+.chat-new-messages:hover {
+	cursor: pointer;
+}
+
+.chat-messages.new-messages + .chat-new-messages {
+	display: block;
+}
+
 /*
  * Wrapper
  */

--- a/http/view/chat.html
+++ b/http/view/chat.html
@@ -5,11 +5,11 @@
 	</div>
 </div>
 
-<div id='chat' class='panel new-messages'>
+<div id='chat' class='panel'>
 
 	<div class='content'>
 
-		<div class='chat-messages new-messages' autostopscroll>
+		<div class='chat-messages' autostopscroll>
 			<div class='websocket-loader'><img src='{{static}}/image/loader.gif' /><br>{#loading_chat}</div>
 		</div>
 

--- a/http/view/chat.html
+++ b/http/view/chat.html
@@ -5,13 +5,15 @@
 	</div>
 </div>
 
-<div id='chat' class='panel'>
+<div id='chat' class='panel new-messages'>
 
 	<div class='content'>
 
-		<div class='chat-messages' autostopscroll>
+		<div class='chat-messages new-messages' autostopscroll>
 			<div class='websocket-loader'><img src='{{static}}/image/loader.gif' /><br>{#loading_chat}</div>
 		</div>
+
+		<div class='chat-new-messages'>Il y a de nouveaux messages non lus !</div>
 
 		<div class='flex'>
 			<div id='chat-language'><img /></div>

--- a/http/view/forum.html
+++ b/http/view/forum.html
@@ -109,6 +109,8 @@
 			<div class='websocket-loader'><img src='{{static}}/image/loader.gif' /><br>{#loading_chat}</div>
 		</div>
 
+		<div class='chat-new-messages'>Il y a de nouveaux messages non lus !</div>
+
 		<div class='flex'>
 			<div id='chat-language'><img /></div>
 			<textarea class='chat-input autogrow' type='text'></textarea>

--- a/http/view/main.html
+++ b/http/view/main.html
@@ -412,6 +412,7 @@
 						<div class='chat-messages' autostopscroll>
 
 						</div>
+						<div class='chat-new-messages'>Il y a de nouveaux messages non lus !</div>
 						<textarea class='chat-input autogrow'></textarea>
 					</div>
 				</div>


### PR DESCRIPTION
- Indiquer si il y a des nouveaux messages dans un bandeau;
- Bien garder le défilement automatique si l'utilisateur n'a pas scrollé vers le haut.
