### PR TITLE
Fix reset of effects, TP/inversion for timeline jump

### DIFF
--- a/http/script/game/game.js
+++ b/http/script/game/game.js
@@ -1893,9 +1893,8 @@ var Game = function() {
         $("[id^=effect]").remove()
          $('#turn').text("")
 
-        for (var effect in this.effects) {
-        	this.removeEffect(effect)
-        }
+		this.effects = []
+
         for (var i = 0; i < this.particles.particles.length; i++) {
         	this.particles.particles.splice(i, 1)
         	i--

--- a/http/script/game/game.js
+++ b/http/script/game/game.js
@@ -832,16 +832,25 @@ var Game = function() {
 
 			case ACTION_USE_CHIP:
 
-				if (this.jumping) {
-					this.actionDone()
-					break
-				}
-
 				var launcher = action[1];
 				var cell = action[2];
 				var chip = action[3];
 				var result = action[4];
 				var leeksID = action[5];
+
+				if (this.jumping) {
+					// Update leek cell after teleportation
+					if (chip == 37) {
+						this.leeks[launcher].cell = cell;
+					}
+					// Update leeks cells after inversion
+					if (chip == 39) {
+						this.leeks[leeksID[0]].cell = this.leeks[launcher].cell;
+						this.leeks[launcher].cell = cell;
+					}
+					this.actionDone()
+					break
+				}
 
 				var log = _.lang.get('fight', 'leek_cast',
 					this.colorText(this.leeks[action[1]].name, this.getLeekColor(action[1])),

--- a/http/script/game/game.js
+++ b/http/script/game/game.js
@@ -1003,11 +1003,11 @@ var Game = function() {
 				summon.summoner = this.leeks[caster]
 				summon.active = true;
 
+				summon.drawID = this.addDrawableElement(summon, summon.y);
+
+				this.hud.addEntityBlock(summon);
+
 				if (!this.jumping) {
-					summon.drawID = this.addDrawableElement(summon, summon.y);
-
-					this.hud.addEntityBlock(summon);
-
 					this.log(_.lang.get('fight', 'summon',
 						this.colorText(this.leeks[action[1]].name, this.getLeekColor(action[1])),
 						this.colorText(summon.name, this.getLeekColor(summon.id))
@@ -1033,9 +1033,7 @@ var Game = function() {
 				entity.active = true
 				entity.reborn()
 
-				if (!this.jumping) {
-					entity.drawID = game.addDrawableElement(entity, entity.y)
-				}
+				entity.drawID = game.addDrawableElement(entity, entity.y)
 
 				this.actionDone()
 				break
@@ -1900,7 +1898,7 @@ var Game = function() {
         $("#actions .action").remove()
         $("#logs .log").remove()
         $("[id^=effect]").remove()
-         $('#turn').text("")
+        $('#turn').text("")
 
 		this.effects = []
 


### PR DESCRIPTION
Les appels à removeEffects vont déduire des caractéristiques initiales des poireaux les buffs qui se trouvent dans effects, d'où les effets négatifs qui s'affichent. 
Il suffit à la place de réinitialiser le tableau effects.