### PR TITLE
[Editor] Fix creation of AI/folder on AI list's root

### DIFF
--- a/http/script/editor.js
+++ b/http/script/editor.js
@@ -336,6 +336,14 @@ LW.pages.editor.init = function(params, $scope, $page) {
 			}
 		}
 
+		// Base folder selection
+		$('#ai-list').click(function() {
+			currentItem = 0;
+			currentType = 'baseFolder'
+			$('#ai-list .item').removeClass('selected')
+			$('#ai-list .folder[id=' + currentItem + ']').addClass('selected')
+		})
+
 		// New button
 		$('#new-button').click(function() {
 			var current_folder = get_current_folder()


### PR DESCRIPTION
Add the possibility to click on a AI list's blank space which allow
the selection of the root folder.

addClass('selected') is not required but it could be used to show that the root is selected.

resolves: #161