### PR TITLE
Fix multiple same chip/weapon in a leek's inventory

### DIFF
--- a/http/lang/en/leek.lang
+++ b/http/lang/en/leek.lang
@@ -37,6 +37,8 @@ error_under_required_level_2	Your second leek must be level %s.
 error_under_required_level_3	Your third leek must be level %s.
 error_under_required_level_weapon		%s doesn't have the required level for this weapon.
 error_under_required_level_chip			%s doesn't have the required level for this chip.
+error_weapon_already_equipped			The weapon is already equipped on %s.
+error_chip_already_equipped				The chip is alredy equipped on %s.
 error_max_weapon						%s can't equip an additional weapon.
 error_max_chip							%s can't equip an additional chip.
 farmed_by						Raised by <a class="leek-farmer" href="/farmer/%1$s">%2$s</a>

--- a/http/lang/fr/leek.lang
+++ b/http/lang/fr/leek.lang
@@ -37,6 +37,8 @@ error_under_required_level_2	Votre second poireau doit être de niveau %s.
 error_under_required_level_3	Votre troisième poireau doit être de niveau %s.
 error_under_required_level_weapon		%s n'a pas le niveau requis pour cette arme.
 error_under_required_level_chip			%s n'a pas le niveau requis pour cette puce.
+error_weapon_already_equipped			L'arme est déjà équipée sur %s.
+error_chip_already_equipped				La puce est déjà équipée sur %s.
 error_max_weapon						%s ne peut pas équiper une arme supplémentaire.
 error_max_chip							%s ne peut pas équiper une puce supplémentaire.
 farmed_by						Élevé par <a class="leek-farmer" href="/farmer/%1$s">%2$s</a> 

--- a/http/script/editor.js
+++ b/http/script/editor.js
@@ -1253,15 +1253,27 @@ LW.pages.editor.test_popup = function(ais) {
 	})
 	add_chip_popup.find('.chip').click(function() {
 		var chip = parseInt($(this).attr('chip'))
-		_current_leek.chips.push(chip)
+		var chip_already_equipped = false
+		for(var c of _current_leek.chips)
+		{
+			if(c == chip) {
+				chip_already_equipped = true
+				break
+			}
+		}
+		if(chip_already_equipped)
+			_.toast('chip_already_equipped', 1200)
+		else {
+			_current_leek.chips.push(chip)
+			var e = $(this).clone()
+			_testPopup.find('.leek-column .chips .container').append(e)
+			add_chip_events(e)
+			add_chip_popup.dismiss()
+			save_leek(_current_leek)
+		}
 		if (_current_leek.chips.length >= 12) {
 			_testPopup.find('.chips .add').hide()
 		}
-		var e = $(this).clone()
-		_testPopup.find('.leek-column .chips .container').append(e)
-		add_chip_events(e)
-		add_chip_popup.dismiss()
-		save_leek(_current_leek)
 	})
 	var add_weapon_popup = new _.popup.new('editor.editor_weapons_popup', {weapons: LW.weapons})
 	_testPopup.find('.leek-column .weapons .add').click(function(e) {
@@ -1269,15 +1281,27 @@ LW.pages.editor.test_popup = function(ais) {
 	})
 	add_weapon_popup.find('.weapon').click(function() {
 		var weapon = parseInt($(this).attr('weapon'))
-		_current_leek.weapons.push(weapon)
+		var weapon_already_equipped = false
+		for(var w of _current_leek.weapons)
+		{
+			if(w == weapon) {
+				weapon_already_equipped = true
+				break
+			}
+		}
+		if(weapon_already_equipped)
+			_.toast('weapon_already_equipped', 1200)
+		else {
+			_current_leek.weapons.push(weapon)
+			var e = $(this).clone()
+			_testPopup.find('.leek-column .weapons .container').append(e)
+			add_weapon_events(e)
+			add_weapon_popup.dismiss()
+			save_leek(_current_leek)
+		}
 		if (_current_leek.weapons.length >= 4) {
 			_testPopup.find('.weapons .add').hide()
 		}
-		var e = $(this).clone()
-		_testPopup.find('.leek-column .weapons .container').append(e)
-		add_weapon_events(e)
-		add_weapon_popup.dismiss()
-		save_leek(_current_leek)
 	})
 
 	/*

--- a/http/script/editor.js
+++ b/http/script/editor.js
@@ -1262,7 +1262,7 @@ LW.pages.editor.test_popup = function(ais) {
 			}
 		}
 		if(chip_already_equipped)
-			_.toast('chip_already_equipped', 1200)
+			_.toast(_.lang.get('leek', 'error_chip_already_equipped', _current_leek.name))
 		else {
 			_current_leek.chips.push(chip)
 			var e = $(this).clone()
@@ -1290,7 +1290,7 @@ LW.pages.editor.test_popup = function(ais) {
 			}
 		}
 		if(weapon_already_equipped)
-			_.toast('weapon_already_equipped', 1200)
+			_.toast(_.lang.get('leek', 'error_weapon_already_equipped', _current_leek.name))
 		else {
 			_current_leek.weapons.push(weapon)
 			var e = $(this).clone()

--- a/http/script/leek.js
+++ b/http/script/leek.js
@@ -684,6 +684,12 @@ LW.pages.leek.weapons = function(leek) {
 				_.toast(_.lang.get('leek', 'error_under_required_level_weapon', leek.name))
 				return
 			}
+			for(var w of leek.weapons){
+ 				if(w.template == weaponTemplate){
+ 					_.toast(_.lang.get('leek', 'error_weapon_already_equipped', leek.name))
+ 					return
+ 				}
+ 			}
 
 			popup.view.find('.leek-weapons').append(weaponElem)
 			weaponElem.attr('location', 'leek')
@@ -795,6 +801,12 @@ LW.pages.leek.chips = function(leek) {
 				_.toast(_.lang.get('leek', 'error_under_required_level_chip', leek.name))
 				return
 			}
+			for(var c of leek.chips){
+ 				if(c.template == chipTemplate){
+ 					_.toast(_.lang.get('leek', 'error_chip_already_equipped', leek.name))
+ 					return
+ 				}
+ 			}
 
 			popup.view.find('.leek-chips').append(chipElem)
 			chipElem.attr('location', 'leek')


### PR DESCRIPTION
Unable the user to add a chip/weapon in a leek inventory if it is already equipped on this leek

resolve: #159 