### PR TITLE
[Report] Fix the highlight statistics table's bug

### DIFF
--- a/http/script/report.js
+++ b/http/script/report.js
@@ -743,7 +743,7 @@ LW.pages.report.highlightStatisticsTable = function(statistics) {
 		var bestl = null
 
 		for (var l = 0; l < leeks; ++l) {
-			var v = parseFloat($($(trs[l]).find('td')[c]).text().replace(/( |\u00a0)/g, ''));
+			var v = parseFloat($($(trs[l]).find('td')[c]).text().replace(/( |\u00a0)/g, ''))
 			if (v > best) {
 				best = v
 				bestl = l

--- a/http/script/report.js
+++ b/http/script/report.js
@@ -743,7 +743,7 @@ LW.pages.report.highlightStatisticsTable = function(statistics) {
 		var bestl = null
 
 		for (var l = 0; l < leeks; ++l) {
-			var v = parseFloat($($(trs[l]).find('td')[c]).text().replace(/ /g, ''))
+			var v = parseFloat($($(trs[l]).find('td')[c]).text().replace(/( |\u00a0)/g, ''));
 			if (v > best) {
 				best = v
 				bestl = l


### PR DESCRIPTION
La regex qui enlevait les espaces ne prenait pas en compte les espaces insécables des séparateurs des milliers, ce qui causait la mise en évidence de mauvaises valeurs
![image](https://cloud.githubusercontent.com/assets/17564388/23833226/fe2e196e-0742-11e7-9708-198836e0ef8d.png) -> ![image](https://cloud.githubusercontent.com/assets/17564388/23833237/195f2c1e-0743-11e7-9951-613fc65ab6bf.png)
