### PR TITLE
[Leek] Improve equipment ui

### DIFF
--- a/http/lang/en/leek.lang
+++ b/http/lang/en/leek.lang
@@ -39,6 +39,8 @@ error_under_required_level_weapon		%s doesn't have the required level for this w
 error_under_required_level_chip			%s doesn't have the required level for this chip.
 error_max_weapon						%s can't equip an additional weapon.
 error_max_chip							%s can't equip an additional chip.
+error_weapon_already_equipped			%s has already equipped this weapon.
+error_chip_already_equipped				%s has already equipped this chip.
 farmed_by						Raised by <a class="leek-farmer" href="/farmer/%1$s">%2$s</a>
 fights							Fights
 frequency						Frequency

--- a/http/lang/fr/leek.lang
+++ b/http/lang/fr/leek.lang
@@ -39,6 +39,8 @@ error_under_required_level_weapon		%s n'a pas le niveau requis pour cette arme.
 error_under_required_level_chip			%s n'a pas le niveau requis pour cette puce.
 error_max_weapon						%s ne peut pas équiper une arme supplémentaire.
 error_max_chip							%s ne peut pas équiper une puce supplémentaire.
+error_weapon_already_equipped			%s a déjà équipé cette arme.
+error_chip_already_equipped				%s a déjà équipé cette puce.
 farmed_by						Élevé par <a class="leek-farmer" href="/farmer/%1$s">%2$s</a> 
 fights							Combats
 frequency						Fréquence

--- a/http/script/leek.js
+++ b/http/script/leek.js
@@ -778,81 +778,94 @@ LW.pages.leek.weapons = function(leek) {
 				return
 			}
 
-			// Add weapon to leek inventory in popup
-			var newElem = weaponElem
-				.clone()
-				.attr('id', "popup-leek-weapon-" + weaponID)
-				.attr('location', 'leek')
-				.removeAttr('quantity')
-				.on(weaponEventsFunctions)
+			_.post('leek/add-weapon', {leek_id: leek.id, weapon_id: weaponItem}, function(data) {
+				if(data.success) {
+					// Add weapon to leek inventory in popup
+					var newElem = weaponElem
+						.clone()
+						.attr('id', "popup-leek-weapon-" + weaponID)
+						.attr('item', data.id)
+						.attr('location', 'leek')
+						.removeAttr('quantity')
+						.on(weaponEventsFunctions)
 
-			insertWeapon(popup.view.find('.leek-weapons'), newElem, weaponPosition)
+					insertWeapon(popup.view.find('.leek-weapons'), newElem, weaponPosition)
 
-			LW.addTooltip('popup-leek-weapon-' + weaponID, '<b>' + _.lang.get('weapon', LW.weapons[weaponID].name) + '</b>')
+					LW.addTooltip('popup-leek-weapon-' + weaponID, '<b>' + _.lang.get('weapon', LW.weapons[weaponID].name) + '</b>')
 
-			// Add weapon to leek inventory on the leek page
-			newElem = weaponElem
-				.clone()
-				.attr('id', "leek-weapon-" + weaponID)
-				.removeAttr('location')
-				.removeAttr('quantity')
-				.on(weaponEventsFunctions)
+					// Add weapon to leek inventory on the leek page
+					newElem = weaponElem
+						.clone()
+						.attr('id', "leek-weapon-" + weaponID)
+						.attr('item', data.id)
+						.removeAttr('location')
+						.removeAttr('quantity')
+						.on(weaponEventsFunctions)
 
-			insertWeapon($('#leek-weapons'), newElem, weaponPosition)
-			newElem.after("<br>")
+					insertWeapon($('#leek-weapons'), newElem, weaponPosition)
+					newElem.after("<br>")
 
-			LW.addTooltip("leek-weapon-" + weaponID, "<b>" + _.lang.get('weapon', weapon.name) + "</b><br>" +
-				_.lang.get('leek', 'level_n', weapon.level) + "<br>WEAPON_" + weapon.name.toUpperCase())
+					LW.addTooltip("leek-weapon-" + weaponID, "<b>" + _.lang.get('weapon', weapon.name) + "</b><br>" +
+						_.lang.get('leek', 'level_n', weapon.level) + "<br>WEAPON_" + weapon.name.toUpperCase())
 
-			// Update farmer inventory
-			if (weaponQuantity > 1) {
-				weaponElem.attr('quantity', weaponQuantity - 1)
-			} else {
-				weaponElem.remove()
-				$('#tt_' + weaponElem.attr('id')).remove()
-			}
+					// Update farmer inventory
+					if (weaponQuantity > 1) {
+						weaponElem.attr('quantity', weaponQuantity - 1)
+					} else {
+						weaponElem.remove()
+						$('#tt_' + weaponElem.attr('id')).remove()
+					}
 
-			leek.weapons.push({id: weaponItem, template: weaponID})
-			_.post('leek/add-weapon', {leek_id: leek.id, weapon_id: weaponItem}, function(r) { console.log(r) })
+					leek.weapons.push({id: data.id, template: weaponID})
+					$('.weapon-count').text('[' + leek.weapons.length + '/' + leek.max_weapons + "]")
+
+				} else {
+					_.toast(data.error)
+				}
+			})
 
 		} else if (action == 'remove') {
 
-
 			if (weaponLocation == 'farmer') return null
 
-			// Add weapon to farmer inventory in popup
-			var farmerWeapon = popup.view.find('.weapon[weapon=' + weaponID + "][location='farmer']")
+			_.post('leek/remove-weapon', {weapon_id: weaponItem}, function(data) {
+				if(data.success) {
+					// Add weapon to farmer inventory in popup
+					var farmerWeapon = popup.view.find('.weapon[weapon=' + weaponID + "][location='farmer']")
 
-			if (farmerWeapon.length > 0) {
-				farmerWeapon.attr('quantity', parseInt(farmerWeapon.attr('quantity')) + 1)
-			} else {
-				newElem = weaponElem
-					.clone()
-					.attr('id', "popup-farmer-weapon-" + weaponID)
-					.attr('location', 'farmer')
-					.attr('quantity', 1)
-					.on(weaponEventsFunctions)
+					if (farmerWeapon.length > 0) {
+						farmerWeapon.attr('quantity', parseInt(farmerWeapon.attr('quantity')) + 1)
+					} else {
+						newElem = weaponElem
+							.clone()
+							.attr('id', "popup-farmer-weapon-" + weaponID)
+							.attr('location', 'farmer')
+							.attr('quantity', 1)
+							.on(weaponEventsFunctions)
 
-				insertWeapon(popup.view.find('.farmer-weapons'), newElem, weaponPosition)
+						insertWeapon(popup.view.find('.farmer-weapons'), newElem, weaponPosition)
 
-				LW.addTooltip('popup-farmer-weapon-' + weaponID, '<b>' + _.lang.get('weapon', LW.weapons[weaponid].name) + '</b>')
-			}
+						LW.addTooltip('popup-farmer-weapon-' + weaponID, '<b>' + _.lang.get('weapon', LW.weapons[weaponid].name) + '</b>')
+					}
 
-			// Remove weapon in popup
-			weaponElem.remove()
-			$('#tt_' + weaponElem.attr('id')).remove()
+					// Remove weapon in popup
+					weaponElem.remove()
+					$('#tt_' + weaponElem.attr('id')).remove()
 
-			// Remove weapon on the leek page
-			var leekPageWeapon = $('#leek-weapons').find(".weapon[weapon='" + weaponID + "']")
-			if(leekPageWeapon.next().prop("tagName") === "BR") leekPageWeapon.next().remove()
-			leekPageWeapon.remove()
-			$('#tt_leek-weapon-' + weaponID).remove()
+					// Remove weapon on the leek page
+					var leekPageWeapon = $('#leek-weapons').find(".weapon[weapon='" + weaponID + "']")
+					if(leekPageWeapon.next().prop("tagName") === "BR") leekPageWeapon.next().remove()
+					leekPageWeapon.remove()
+					$('#tt_leek-weapon-' + weaponID).remove()
 
-			_.removeWhere(leek.weapons, 'id', weaponItem)
-			_.post('leek/remove-weapon', {weapon_id: weaponItem}, function(r) { console.log(r) })
+					_.removeWhere(leek.weapons, 'id', weaponItem)
+					$('.weapon-count').text('[' + leek.weapons.length + '/' + leek.max_weapons + "]")
+
+				} else {
+					_.toast(data.error)
+				}
+			})
 		}
-
-		$('.weapon-count').text('[' + leek.weapons.length + '/' + leek.max_weapons + "]")
 	}
 
 	popup.view.find('.weapon.available').on(weaponEventsFunctions)
@@ -989,77 +1002,93 @@ LW.pages.leek.chips = function(leek) {
 				return
 			}
 
-			// Add chip to leek inventory in popup
-			var newElem = chipElem
-				.clone()
-				.attr('id', "popup-leek-chip-" + chipID)
-				.attr('location', 'leek')
-				.removeAttr('quantity')
-				.on(chipEventsFunctions)
+			_.post('leek/add-chip', {leek_id: leek.id, chip_id: chipItem}, function(data) {
+				if(data.success) {
+					console.log('DATA', data)
+					// Add chip to leek inventory in popup
+					var newElem = chipElem
+						.clone()
+						.attr('id', "popup-leek-chip-" + chipID)
+						.attr('item', data.id)
+						.attr('location', 'leek')
+						.removeAttr('quantity')
+						.on(chipEventsFunctions)
 
-			insertChip(popup.view.find('.leek-chips'), newElem, chipPosition)
+					insertChip(popup.view.find('.leek-chips'), newElem, chipPosition)
 
-			LW.addTooltip('popup-leek-chip-' + chipID, '<b>' + _.lang.get('chip', LW.chips[chipID].name) + '</b>')
+					LW.addTooltip('popup-leek-chip-' + chipID, '<b>' + _.lang.get('chip', LW.chips[chipID].name) + '</b>')
 
-			// Add chip to leek inventory on the leek page
-			newElem = chipElem
-				.clone()
-				.attr('id', "leek-chip-" + chipID)
-				.removeAttr('location')
-				.removeAttr('quantity')
-				.on(chipEventsFunctions)
+					// Add chip to leek inventory on the leek page
+					newElem = chipElem
+						.clone()
+						.attr('id', "leek-chip-" + chipID)
+						.attr('item', data.id)
+						.removeAttr('location')
+						.removeAttr('quantity')
+						.on(chipEventsFunctions)
 
-			insertChip($('#leek-chips'), newElem, chipPosition)
+					insertChip($('#leek-chips'), newElem, chipPosition)
 
-			LW.addTooltip("leek-chip-" + chipID, "<b>" + _.lang.get('chip', chip.name) + "</b><br>" +
-				_.lang.get('leek', 'level_n', chip.level) + "<br>CHIP_" + chip.name.toUpperCase())
+					LW.addTooltip("leek-chip-" + chipID, "<b>" + _.lang.get('chip', chip.name) + "</b><br>" +
+						_.lang.get('leek', 'level_n', chip.level) + "<br>CHIP_" + chip.name.toUpperCase())
 
-			// Update farmer inventory
-			if (chipQuantity > 1) {
-				chipElem.attr('quantity', chipQuantity - 1)
-			} else {
-				chipElem.remove()
-				$('#tt_' + chipElem.attr('id')).remove()
-			}
+					// Update farmer inventory
+					if (chipQuantity > 1) {
+						chipElem.attr('quantity', chipQuantity - 1)
+					} else {
+						chipElem.remove()
+						$('#tt_' + chipElem.attr('id')).remove()
+					}
 
-			leek.chips.push({id: chipItem, template: chipID})
-			_.post('leek/add-chip', {leek_id: leek.id, chip_id: chipItem})
+					leek.chips.push({id: data.id, template: chipID})
+					$('.chip-count').text('[' + leek.chips.length + '/' + leek.max_chips + "]")
+
+				} else {
+					_.toast(data.error)
+				}
+			})
 
 		} else if (action == 'remove') {
 
 			if (chipLocation == 'farmer') return null
 
-			// Add chip to farmer inventory in popup
-			var farmerChip = popup.view.find('.chip[chip=' + chipID + "][location='farmer']")
+			_.post('leek/remove-chip', {chip_id: chipItem}, function(data) {
+				console.log('DATA', data)
+				if(data.success) {
+					// Add chip to farmer inventory in popup
+					var farmerChip = popup.view.find('.chip[chip=' + chipID + "][location='farmer']")
 
-			if (farmerChip.length > 0) {
-				farmerChip.attr('quantity', parseInt(farmerChip.attr('quantity')) + 1)
-			} else {
-				newElem = chipElem
-					.clone()
-					.attr('id', "popup-farmer-chip-" + chipID)
-					.attr('location', 'farmer')
-					.attr('quantity', 1)
-					.on(chipEventsFunctions)
+					if (farmerChip.length > 0) {
+						farmerChip.attr('quantity', parseInt(farmerChip.attr('quantity')) + 1)
+					} else {
+						newElem = chipElem
+							.clone()
+							.attr('id', "popup-farmer-chip-" + chipID)
+							.attr('location', 'farmer')
+							.attr('quantity', 1)
+							.on(chipEventsFunctions)
 
-				insertChip(popup.view.find('.farmer-chips'), newElem, chipPosition)
+						insertChip(popup.view.find('.farmer-chips'), newElem, chipPosition)
 
-				LW.addTooltip('popup-farmer-chip-' + chipID, '<b>' + _.lang.get('chip', LW.chips[chipID].name) + '</b>')
-			}
+						LW.addTooltip('popup-farmer-chip-' + chipID, '<b>' + _.lang.get('chip', LW.chips[chipID].name) + '</b>')
+					}
 
-			// Remove chip in popup
-			chipElem.remove()
-			$('#tt_' + chipElem.attr('id')).remove()
+					// Remove chip in popup
+					chipElem.remove()
+					$('#tt_' + chipElem.attr('id')).remove()
 
-			// Remove chip on the leek page
-			$('#leek-chips').find(".chip[chip='" + chipID + "']").remove()
-			$('#tt_leek-chip-' + chipID).remove()
+					// Remove chip on the leek page
+					$('#leek-chips').find(".chip[chip='" + chipID + "']").remove()
+					$('#tt_leek-chip-' + chipID).remove()
 
-			_.removeWhere(leek.chips, 'id', chipItem)
-			_.post('leek/remove-chip', {chip_id: chipItem})
+					_.removeWhere(leek.chips, 'id', chipItem)
+					$('.chip-count').text('[' + leek.chips.length + '/' + leek.max_chips + "]")
+
+				} else {
+					_.toast(data.error)
+				}
+			})
 		}
-
-   		$('.chip-count').text('[' + leek.chips.length + '/' + leek.max_chips + "]")
 	}
 
 	popup.view.find('.chip.available').on(chipEventsFunctions)

--- a/http/script/leek.js
+++ b/http/script/leek.js
@@ -43,14 +43,9 @@ LW.pages.leek.init = function(params, $scope, $page) {
 
 		leek.talent_gains = Math.round(leek.talent_more / 3)
 
-		leek.orderedChips = leek.chips
-			.map(function(chip) {
-				chip.position = LW.orderedChips[chip.template]
-				return chip
-			})
-			.sort(function(chipA, chipB) {
-				return chipA.position - chipB.position
-			})
+		leek.orderedChips = leek.chips.sort(function(chipA, chipB) {
+			return LW.orderedChips[chipA.template] - LW.orderedChips[chipB.template]
+		})
 
 		$scope.leek = leek
 		$scope.my_leek = myLeek
@@ -847,7 +842,7 @@ LW.pages.leek.chips = function(leek) {
 
 		if(children.length > 0) {
 			while(i < children.length && !inserted) {
-				if(parseInt(children.eq(i).attr('position')) > position) {
+				if(LW.orderedChips[parseInt(children.eq(i).attr('chip'))] > position) {
 					children.eq(i).before(elem)
 					inserted = true
 				}
@@ -866,7 +861,7 @@ LW.pages.leek.chips = function(leek) {
 		var chipElem = popup.view.find('.chip[chip=' + chipID + "][location='" + chipContainer + "']")
 		var chipItem = parseInt(chipElem.attr('item'))
 		var chipLocation = chipElem.attr('location')
-		var chipPosition = chipElem.attr('position')
+		var chipPosition = LW.orderedChips[chipID]
 		var chip = LW.chips[chipID]
 		
 		chipElem.removeClass('dragging')

--- a/http/script/main.js
+++ b/http/script/main.js
@@ -848,6 +848,7 @@ LW.init = function(callback) {
 	}
 
 	LW.orderedChips = LW.orderChips(LW.chips)
+	LW.orderedWeapons = LW.orderWeapons(LW.weapons)
 
 	all = true
 	++count && ready()
@@ -3067,7 +3068,18 @@ LW.orderChips = function(chips) {
 	}
 
 	return orderedChips
-} 
+}
+
+LW.orderWeapons = function(weapons) {
+	// Order weapons by level
+	var orderedWeapons = {}
+	var position = 0
+	for(var i in weapons) {
+		orderedWeapons[weapons[i].id] = position++
+	}
+
+	return orderedWeapons
+}
 
 LW.createWeaponPreview = function(template) {
 

--- a/http/script/main.js
+++ b/http/script/main.js
@@ -847,6 +847,8 @@ LW.init = function(callback) {
 		}
 	}
 
+	LW.orderedChips = LW.orderChips(LW.chips)
+
 	all = true
 	++count && ready()
 }
@@ -3035,6 +3037,37 @@ LW.getChipIDByName = function(name) {
 	}
 	return null
 }
+
+LW.orderChips = function(chips) {
+	// Regroup chips by effects type
+	var chipsByType = {}
+	for(var i in chips) {
+		var chip = chips[i]
+		var type = chip.effects[0].type
+
+		if(chipsByType[type] === undefined) chipsByType[type] = []
+		chipsByType[type].push(chip)
+	}
+
+	// Order chips by level and associates each chips with his position
+	var orderedChips = {}
+	var position = 0
+	for(var i in LW.EFFECT_TYPES) {
+		var type = LW.EFFECT_TYPES[i]
+		if(chipsByType[type] !== undefined) {
+			
+			chipsByType[type]
+				.sort(function(chipA, chipB) {
+					return chipA.level - chipB.level  
+				})
+				.forEach(function(chip) {
+					orderedChips[chip.id] = position++
+				})
+		}
+	}
+
+	return orderedChips
+} 
 
 LW.createWeaponPreview = function(template) {
 

--- a/http/script/market.js
+++ b/http/script/market.js
@@ -310,19 +310,6 @@ LW.pages.market.selectItem = function(item) {
 LW.pages.market.chips = function(sort_method) {
 	var self = this
 
-	// Hardcodage dégeu parce que wala - A supprimer
-	var typeLang = {
-		1 : "Attaques",
-		2 : "Soins",
-		3 : "Boosts",
-		4 : "Protections",
-		5 : "Tactiques",
-		6 : "Renvois",
-		7 : "Poisons",
-		8 : "Bulbes",
-		9 : "Debuffs"
-	}
-
 	var sort_mode = localStorage.getItem('market/sort_mode') == 'type' ? 'type' : 'level';
 
 	// Distributed chips according to their type

--- a/http/style/leek.css
+++ b/http/style/leek.css
@@ -603,10 +603,11 @@
 /*
  * Count indicator
  */
-.farmer-chips .chip {
+.farmer-weapons .weapon, .farmer-chips .chip {
 	position: relative;
 }
 
+.farmer-weapons .weapon:not([quantity='1']):before,
 .farmer-chips .chip:not([quantity='1']):before {
 	position: absolute;
 	bottom: -5px;

--- a/http/style/leek.css
+++ b/http/style/leek.css
@@ -599,3 +599,24 @@
 	color: red;
 	margin-left: 6px;
 }
+
+/*
+ * Count indicator
+ */
+.farmer-chips .chip {
+	position: relative;
+}
+
+.farmer-chips .chip:not([quantity='1']):before {
+	position: absolute;
+	bottom: -5px;
+	right: -5px;
+	width: 20px;
+	height: 20px;
+	content: attr(quantity);
+	text-align: center;
+	color: #eee;
+	border-radius: 20px;
+	background-color: #0a0;
+	font-weight: bold;
+}

--- a/http/view/leek.html
+++ b/http/view/leek.html
@@ -360,12 +360,12 @@
 			</div>
 
 			<div id='leek-weapons' class='content'>
-				@foreach (i : weapon in leek.weapons)
-					<div id="leek-weapon-{i}" weapon="{i}" item="{weapon.id}" template="{weapon.template}" class="weapon available">
+				@foreach (i : weapon in leek.orderedWeapons)
+					<div id="leek-weapon-{weapon.template}" class="weapon available" item="{weapon.id}" weapon="{weapon.template}">
 						<img src="{{static}}/image/weapon/{LW.weapons[weapon.template].name}.png">
 					</div>
 					<br>
-					<div class='tooltip' id='tt_leek-weapon-{i}'>
+					<div class='tooltip' id='tt_leek-weapon-{weapon.template}'>
 						<b>{_.lang.get('weapon', LW.weapons[weapon.template].name)}</b>
 						<br>
 						{#weapon_level_n, LW.weapons[weapon.template].level}
@@ -533,11 +533,11 @@
 	<div class='content' autostopscroll>
 		<div class='leek-weapons'>
 
-			@foreach (i : weapon in leek.weapons)
-				<div id='weapon-{weapon.id}-{i}' class='weapon available' location='leek' weapon="{weapon.id}-{i}" item='{weapon.id}' template='{weapon.template}'>
+			@foreach (i : weapon in leek.orderedWeapons)
+				<div id='popup-leek-weapon-{weapon.template}' class='weapon available' location='leek' item='{weapon.id}' weapon='{weapon.template}'>
 					<img src='{{static}}image/weapon/{LW.weapons[weapon.template].name}.png'>
 				</div>
-				<div class='tooltip' id='tt_weapon-{weapon.id}-{i}'>
+				<div class='tooltip' id='tt_popup-leek-weapon-{weapon.template}'>
 					<b>{_.lang.get('weapon', LW.weapons[weapon.template].name)}</b>
 				</div>
 			@end
@@ -550,10 +550,10 @@
 
 		<div class='farmer-weapons'>
 			@foreach (i : weapon in farmer_weapons)
-				<div id='weapon-{weapon.id}-{i}' class='weapon available' location='farmer' weapon="{weapon.id}-{i}" item='{weapon.id}' template='{weapon.template}'>
+				<div id='popup-farmer-weapon-{weapon.template}' class='weapon available' location='farmer' item='{weapon.id}' weapon='{weapon.template}' quantity='{weapon.quantity}'>
 					<img src='{{static}}image/weapon/{LW.weapons[weapon.template].name}.png'>
 				</div>
-				<div class='tooltip' id='tt_weapon-{weapon.id}-{i}'>
+				<div class='tooltip' id='tt_popup-farmer-weapon-{weapon.template}'>
 					<b>{_.lang.get('weapon', LW.weapons[weapon.template].name)}</b>
 				</div>
 			@end

--- a/http/view/leek.html
+++ b/http/view/leek.html
@@ -391,11 +391,11 @@
 
 			<div class='content center'>
 				<div id='leek-chips'>
-					@foreach (chip in leek.chips)
-						<div id="leek-chip-{chip.id}" item="{chip.id}" template="{chip.template}" class="chip available">
+					@foreach (chip in leek.orderedChips)
+						<div id="leek-chip-{chip.template}" class="chip available" item="{chip.id}" chip="{chip.template}" position="{chip.position}">
 							<img src="{{static}}/image/chip/small/{LW.chips[chip.template].name}.png">
 						</div>
-						<div class='tooltip' id='tt_leek-chip-{chip.id}'>
+						<div class='tooltip' id='tt_leek-chip-{chip.template}'>
 							<b>{_.lang.get('chip', LW.chips[chip.template].name)}</b>
 							<br>
 							{#chip_level_n, LW.chips[chip.template].level}
@@ -572,11 +572,11 @@
 	<div class='content' autostopscroll>
 
 		<div class='leek-chips'>
-			@foreach (i : chip in leek.chips)
-				<div id='chip-{chip.id}-{i}' class='chip available' location='leek' chip='{chip.id}-{i}' item='{chip.id}' template='{chip.template}'>
+			@foreach (i : chip in leek.orderedChips)
+				<div id='popup-leek-chip-{chip.template}' class='chip available' location='leek' item='{chip.id}' chip='{chip.template}' position='{chip.position}'>
 					<img src='{{static}}image/chip/small/{LW.chips[chip.template].name}.png'>
 				</div>
-				<div class='tooltip' id='tt_chip-{chip.id}-{i}'>
+				<div class='tooltip' id='tt_popup-leek-chip-{chip.template}'>
 					<b>{_.lang.get('chip', LW.chips[chip.template].name)}</b>
 				</div>
 			@end
@@ -589,10 +589,10 @@
 
 		<div class='farmer-chips'>
 			@foreach (i : chip in farmer_chips)
-				<div id='chip-{chip.id}-{i}' class='chip available' location='farmer' chip='{chip.id}-{i}' item='{chip.id}' template='{chip.template}'>
+				<div id='popup-farmer-chip-{chip.template}' class='chip available' location='farmer' item='{chip.id}' chip='{chip.template}' position='{chip.position}' quantity='{chip.quantity}'>
 					<img src='{{static}}image/chip/small/{LW.chips[chip.template].name}.png'>
 				</div>
-				<div class='tooltip' id='tt_chip-{chip.id}-{i}'>
+				<div class='tooltip' id='tt_popup-farmer-chip-{chip.template}'>
 					<b>{_.lang.get('chip', LW.chips[chip.template].name)}</b>
 				</div>
 			@end

--- a/http/view/leek.html
+++ b/http/view/leek.html
@@ -392,7 +392,7 @@
 			<div class='content center'>
 				<div id='leek-chips'>
 					@foreach (chip in leek.orderedChips)
-						<div id="leek-chip-{chip.template}" class="chip available" item="{chip.id}" chip="{chip.template}" position="{chip.position}">
+						<div id="leek-chip-{chip.template}" class="chip available" item="{chip.id}" chip="{chip.template}">
 							<img src="{{static}}/image/chip/small/{LW.chips[chip.template].name}.png">
 						</div>
 						<div class='tooltip' id='tt_leek-chip-{chip.template}'>
@@ -573,7 +573,7 @@
 
 		<div class='leek-chips'>
 			@foreach (i : chip in leek.orderedChips)
-				<div id='popup-leek-chip-{chip.template}' class='chip available' location='leek' item='{chip.id}' chip='{chip.template}' position='{chip.position}'>
+				<div id='popup-leek-chip-{chip.template}' class='chip available' location='leek' item='{chip.id}' chip='{chip.template}'>
 					<img src='{{static}}image/chip/small/{LW.chips[chip.template].name}.png'>
 				</div>
 				<div class='tooltip' id='tt_popup-leek-chip-{chip.template}'>
@@ -589,7 +589,7 @@
 
 		<div class='farmer-chips'>
 			@foreach (i : chip in farmer_chips)
-				<div id='popup-farmer-chip-{chip.template}' class='chip available' location='farmer' item='{chip.id}' chip='{chip.template}' position='{chip.position}' quantity='{chip.quantity}'>
+				<div id='popup-farmer-chip-{chip.template}' class='chip available' location='farmer' item='{chip.id}' chip='{chip.template}' quantity='{chip.quantity}'>
 					<img src='{{static}}image/chip/small/{LW.chips[chip.template].name}.png'>
 				</div>
 				<div class='tooltip' id='tt_popup-farmer-chip-{chip.template}'>


### PR DESCRIPTION
Ajout d'erreurs "error_weapon_already_equipped" et "error_chip_already_equipped"
Il est désormais impossible d'équiper deux fois une même puce.

AJout d'une fonction orderChips dans LW.
Elle permet d'obtenir un objet associant un id de puce à un numéro de position.
Les positions correspondent aux puces ordonnées par type et pas niveau.

LW.orderedChips contient le retour de orderChips pour toutes les puces

Sur la page d'un poireau, et dans la popup d'équipement, les puces sont affichées dans l'ordre définit par LW.orderedChips
Dans la partie de la popup qui affiche les puces de l'éleveur, celles-ci sont regroupés en une seule.
La quantité est indiqué de la même façon que sur le Marché.

Modifications similaires pour les armes.

Suppression d'un ancien objet harcoder pour les langues