### PR TITLE
Majuscules à Noël et Christmas

### DIFF
--- a/http/lang/en/hat.lang
+++ b/http/lang/en/hat.lang
@@ -1,6 +1,6 @@
 chinese_hat			Rice hat
 christmas_hat			Christmas Hat
-christmas_hat_desc			Who never dreamed of seeing a leek wearing a christmas hat?
+christmas_hat_desc			Who never dreamed of seeing a leek wearing a Christmas hat?
 crown			Crown
 cyan_christmas_hat			Cyan Christmas Hat
 green_christmas_hat			Green Christmas Hat

--- a/http/lang/fr/hat.lang
+++ b/http/lang/fr/hat.lang
@@ -1,5 +1,5 @@
 chinese_hat				Chapeau chinois
-christmas_hat			Bonnet de noël
+christmas_hat			Bonnet de Noël
 christmas_hat_desc		Qui n'a jamais rêvé de voir un poireau porter un bonnet de Noël ?
 crown					Couronne
 cyan_christmas_hat		Bonnet de Noël turquoise

--- a/http/lang/fr/hat.lang
+++ b/http/lang/fr/hat.lang
@@ -1,9 +1,9 @@
 chinese_hat				Chapeau chinois
 christmas_hat			Bonnet de noël
-christmas_hat_desc		Qui n'a jamais rêvé de voir un poireau porter un bonnet de noël ?
+christmas_hat_desc		Qui n'a jamais rêvé de voir un poireau porter un bonnet de Noël ?
 crown					Couronne
-cyan_christmas_hat		Bonnet de noël turquoise
-green_christmas_hat		Bonnet de noël vert
+cyan_christmas_hat		Bonnet de Noël turquoise
+green_christmas_hat		Bonnet de Noël vert
 harlequin				Arlequin
 mugiwara				Chapeau de paille
 panama					Panama


### PR DESCRIPTION
Certaines occurrences de "Noël" et "Christmas" étaient en minuscules ("noël" et "christmas") et d'autres non.
PR plus que secondaire, mais ça me gênait 😁.