### PR TITLE
[Fight] Fix incorrect display of stats when liberated effect expire

### DIFF
--- a/src/script/game/game.js
+++ b/src/script/game/game.js
@@ -1462,6 +1462,7 @@ var Game = function() {
 				break;
 		}
 		this.hud.updateEntityEffect(id, new_value)
+		effect.value = new_value // Updating the effect's value to properly remove it with `removeEffect`
 	}
 
 	this.readLogs = function() {


### PR DESCRIPTION
When Liberation is used on an entity, only the hud is updated, so when the effect expire, the old value is used in `removeEffect` resulting in incorrect update of the stats displayed. This fix simply update the value contained in `this.effects[id].value`.