### PR TITLE
Update include section in tutorial.lang

### DIFF
--- a/http/lang/fr/tutorial.lang
+++ b/http/lang/fr/tutorial.lang
@@ -21,7 +21,7 @@ advanced_include_7			// ne fonctionne pas
 							include("IA_" + 5);
 advanced_include_8			// ne fonctionne pas
 							var ia = 'IA_1';
-							include('IA_1');
+							include(ia);
 advanced_include_9			// ne fonctionne pas
 							if (foo > 12) {
 								include('IA_1');


### PR DESCRIPTION
Hello,
J'ai changé un des exemples des limites de la [fonctions include](http://leekwars.com/tutorial#includes).
Avant:
![before](https://user-images.githubusercontent.com/24603909/32980683-62ae8886-cc6b-11e7-8a48-3e3838d9d10a.PNG)
Après:
![after](https://user-images.githubusercontent.com/24603909/32980684-650d2eca-cc6b-11e7-8651-77768e76508b.PNG)
Cela m'a l'air plus logique comme ça. À vous de me dire ce que vous en pensez.