### PR TITLE
Update chat_commands.js

### DIFF
--- a/src/script/chat_commands.js
+++ b/src/script/chat_commands.js
@@ -19,6 +19,13 @@ chat_commands.list = [
             description: "Ajoute un lien vers la documentation au message"
         }]
     }, {
+        command: "tuto",
+        regex: /(^| )\/tuto(?=$|\s)/gi,
+        replacement: function(authorName) {
+                return " " + _.toChatLink("/help/tutorial", "tuto", "target='_blank' rel='nofollow'") + " "
+            },
+        description: "Ajoute un lien vers le tutorial au message"
+    }, {
         command: "fliptable",
         regex: /(^| )\/fliptable(?=$|\s)/gi,
         replacement: function(authorName) {


### PR DESCRIPTION
Ajout de la commande /tuto pour afficher un lien vers le tutorial (à la manière de /doc, /wiki...)

j'ai vu qu'il y a des constantes URL_DOC, etc... mais j'ai pas trouvé où elles sont déclarées, du coup j'ai mis le lien en dur :( 