### PR TITLE
feat#487(editor): Automatically save current ai before open test popup

### DIFF
--- a/src/component/editor/editor-page.vue
+++ b/src/component/editor/editor-page.vue
@@ -431,9 +431,11 @@
 							ai.valid = true
 							editor.removeErrors()
 						} else if (code === 1) {
+							this.testDialog = false
 							this.errors.push({ai: ai.name, error: res[2], line: res[3]})
 							ai.valid = false
 						} else if (code === 0) {
+							this.testDialog = false
 							const line = res[3]
 							let info = res[5]
 							if (res.length === 8) {
@@ -513,6 +515,8 @@
 			})
 		}
 		test() {
+			// Save the current ai and open the testDialogBox. Close it if ai doesn't compile
+			this.save()
 			this.testDialog = true
 		}
 		help() {


### PR DESCRIPTION
Expected behaviour: When user click on "launch test" button, the editor
saves ai then opens the test popup. If the ai doesn't compile, the popup
closes by itself

https://github.com/leek-wars/leek-wars-client/issues/487