### PR TITLE
[BUG] [report] Fix life chart ToolTip in fight report

### DIFF
--- a/src/component/report/report.vue
+++ b/src/component/report/report.vue
@@ -621,7 +621,7 @@
 			this.chartTooltipX = x - tooltip.offsetWidth / 2 - 10,
 			this.chartTooltipY = top - 40
 
-			const value = Math.round((this.chart.chartRect.y1 - top) * (this.chartScale / (this.chart.chartRect.y1 - this.chart.chartRect.y2)))
+			const value = Math.round(this.chart.bounds.low + (this.chart.chartRect.y1 - top) * (this.chartScale / (this.chart.chartRect.y1 - this.chart.chartRect.y2)))
 			this.chartTooltipValue = this.statistics.entities[this.chartTooltipLeek].leek.name + '<br>' + value + (this.log ? '%' : '') + ' PV'
 		}
 


### PR DESCRIPTION
Before :
![image](https://user-images.githubusercontent.com/44946745/137991149-47bb3bee-c5e3-4f5f-a75e-6456c1674ab1.png)

After :
![image](https://user-images.githubusercontent.com/44946745/137991238-0752d468-d9d8-47b8-9102-0fd23204e531.png)

The bug is only present for fights that have tied (the minimum diplayed life is then greater than 0).