### PR TITLE
fix: suppression de l'espace de fin sur recherche classement

### DIFF
--- a/src/component/ranking/ranking.vue
+++ b/src/component/ranking/ranking.vue
@@ -417,7 +417,7 @@
 			if (!this.searchQuery.length) {
 				this.searchResults = []
 			} else {
-				LeekWars.post('ranking/search', {query: this.searchQuery, search_leeks: this.searchLeeks, search_farmers: this.searchFarmers, search_teams: this.searchTeams}).then(data => {
+				LeekWars.post('ranking/search', {query: this.searchQuery.trim(), search_leeks: this.searchLeeks, search_farmers: this.searchFarmers, search_teams: this.searchTeams}).then(data => {
 					this.searchResults = data.results
 				})
 			}


### PR DESCRIPTION
Ce cas se produit sur téléphone, quand on commence à taper ou qu'on valide le mot, ça met un espace à la fin, c'est un peu relou à l'usage, et c'est rare qu'une recherche se termine volontairement par un ou plusieurs espaces !