### PR TITLE
Fix stored XSS in conversation preview

### DIFF
--- a/src/component/messages/conversation.vue
+++ b/src/component/messages/conversation.vue
@@ -7,7 +7,7 @@
 			<div class="name">{{ farmer ? farmer.name : '?' }}</div>
 			<div class="last-message">
 				<b v-if="chat.last_farmer && $store.state.farmer && chat.last_farmer.id === $store.state.farmer.id">{{ $t('main.me') }} ►</b>
-				<span v-html="chat.last_message"></span>
+				<span v-text="chat.last_message"></span>
 			</div>
 			<div class="date">{{ LeekWars.formatDuration(chat.last_date) }}</div>
 		</div>


### PR DESCRIPTION
## Summary

The conversation list preview in `src/component/messages/conversation.vue` uses `v-html` to render `chat.last_message`. Since the message content is user-controlled and not sanitized before rendering, an attacker can inject arbitrary HTML/JavaScript via a private message that executes when the victim views their conversation list.

**Vulnerability:** Stored Cross-Site Scripting (CWE-79)

## Fix

Replace `v-html` with `v-text` on line 10 of `conversation.vue`. The conversation preview only displays a plain-text snippet — there is no legitimate need for HTML rendering here.

```diff
- <span v-html="chat.last_message"></span>
+ <span v-text="chat.last_message"></span>
```

`v-text` safely escapes all HTML entities, preventing script injection while preserving the intended display behavior.

## Reproduction

1. Send a PM with content like `<img src=x onerror=alert(document.cookie)>`
2. The victim sees the XSS trigger in their conversation list sidebar without even opening the message

## Impact

- Session hijacking via cookie theft
- Account takeover
- Phishing via injected UI elements

