### PR TITLE
fix: XSS post-DOMPurify dans markdown links()

### DIFF
--- a/src/component/encyclopedia/markdown.vue
+++ b/src/component/encyclopedia/markdown.vue
@@ -382,7 +382,17 @@
 			})
 		}
 
+		escapeHtml(input: string): string {
+			return input
+				.replace(/&/g, '&amp;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;')
+				.replace(/"/g, '&quot;')
+				.replace(/'/g, '&#39;')
+		}
+
 		links(html: string) {
+			const esc = (s: string) => this.escapeHtml(s)
 			return html.replace(/\[\[(.*?)\]\]/g, (m, link) => {
 				link = link.trim()
 				const parts = link.split('|', 2)
@@ -390,8 +400,10 @@
 				const alias = parts.length === 2 ? parts[1] : link
 				const page = LeekWars.encyclopedia[this.language] ? LeekWars.encyclopedia[this.language][link.toLowerCase().replace(/_/g, ' ')] : null
 				const clazz = page ? "" : "new"
-				const text = link.replace(/_/g, ' ').replace(/'/g, '&apos;')
-				return "<a href='/encyclopedia/" + this.language + '/' + (page ? page.title.replace(/ /g, '_') : text) + "' class='" + clazz + "'>" + alias + "</a>"
+				const text = link.replace(/_/g, ' ')
+				const target = page ? page.title.replace(/ /g, '_') : text
+				const href = '/encyclopedia/' + this.language + '/' + target
+				return "<a href='" + esc(href) + "' class='" + clazz + "'>" + esc(alias) + "</a>"
 			}).replace(/{{(.*?)}}/g, (m, tag) => {
 				const originalTag = tag.trim()
 				tag = originalTag.toLowerCase()
@@ -403,19 +415,19 @@
 					const parts = tag.split(':')
 					if (parts.length > 1) {
 						const weapon = parts[1].trim().toLowerCase()
-						return "<div class='encyclopedia-weapon' weapon='" + weapon + "'></div>"
+						return "<div class='encyclopedia-weapon' weapon='" + esc(weapon) + "'></div>"
 					}
 				} else if (tag.startsWith('chip')) {
 					const parts = tag.split(':')
 					if (parts.length > 1) {
 						const chip = parts[1].trim().toLowerCase()
-						return "<div class='encyclopedia-chip' chip='" + chip + "'></div>"
+						return "<div class='encyclopedia-chip' chip='" + esc(chip) + "'></div>"
 					}
 				} else if (tag.startsWith('potion')) {
 					const parts = tag.split(':')
 					if (parts.length > 1) {
 						const potion = parts[1].trim().toLowerCase()
-						return "<div class='encyclopedia-potion' potion='" + potion + "'></div>"
+						return "<div class='encyclopedia-potion' potion='" + esc(potion) + "'></div>"
 					}
 				} else if (tag.startsWith('locked-pages')) {
 					return "<div class='encyclopedia-locked-pages'></div>"
@@ -436,18 +448,18 @@
 					if (parts.length > 1) {
 						const chapter = parseInt(parts[1])
 						const locked = (store.state.farmer ? store.state.farmer.tutorial_progress : 0) < chapter ? "locked": ""
-						return "<div class='lock " + locked + "'>" + this.$parent!.$parent!.$i18n.t('locked') + "</div>"
+						return "<div class='lock " + locked + "'>" + esc(this.$parent!.$parent!.$i18n.t('locked') as string) + "</div>"
 					}
 				} else if (tag.startsWith('alias')) {
 					const parts = originalTag.split(':')
 					if (parts.length > 1) {
 						const alias = parts[1].trim()
-						return "<span class='encyclopedia-alias' data-alias='" + alias.replace(/'/g, '&apos;') + "'></span>"
+						return "<span class='encyclopedia-alias' data-alias='" + esc(alias) + "'></span>"
 					}
 				} else if (tag.startsWith('leeky')) {
 					return "<div class='leeky'></div>"
 				}
-				return '{{ ' + tag + ' }}'
+				return '{{ ' + esc(tag) + ' }}'
 			})
 		}
 


### PR DESCRIPTION
## Contexte

Dans `src/component/encyclopedia/markdown.vue`, le pipeline de rendu est :

1. `DOMPurify.sanitize(this.markdown.render(this.content), …)`
2. `this.html = this.links(sanitized)`
3. Le résultat est injecté via `v-html` dans `<div ref=\"md\" class=\"md\" v-html=\"html\"></div>`.

Le souci : `links()` réécrit la syntaxe wiki `[[Page|alias]]` et les balises template `{{weapon:…}}`, `{{chip:…}}`, `{{potion:…}}`, `{{alias:…}}`, `{{tutorial-lock:…}}`, etc. **après** la passe DOMPurify et concatène directement les sous-chaînes dynamiques dans des attributs `class='…'`, `weapon='…'`, `data-alias='…'` ou dans le texte du lien `<a>…</a>`.

Toute valeur passée au-travers de DOMPurify (qui ne touche pas au texte brut entre `[[` `]]` ou `{{` `}}`) ressort donc intacte côté `v-html`. Comme `apostrophe` et `<` ne sont pas échappés, l'attaquant peut sortir de l'attribut ou injecter du HTML.

### PoC sur une page d'encyclopédie

```
[[SomePage|</a><svg onload=alert(document.cookie)>]]
```

→ `links()` produit `<a … class='new'></a><svg onload=alert(document.cookie)></a>`, qui s'exécute pour tout lecteur de la page.

```
{{weapon:foo' onmouseover='alert(1)' x:'}}
```

→ `links()` produit `<div class='encyclopedia-weapon' weapon='foo' onmouseover='alert(1)' x:''></div>`, qui injecte un gestionnaire d'événement.

L'impact est plus large que la XSS PM (PR #899) car la page wiki est lue par n'importe quel utilisateur, pas seulement le destinataire d'un message privé.

## Correctif

Ajout d'un helper `escapeHtml()` (échappe `& < > \" '`) et application systématique sur **toute** sous-chaîne dynamique injectée par `links()` :

- texte et `href` du lien `[[Page|alias]]`,
- valeur des attributs `weapon`, `chip`, `potion`, `data-alias`,
- texte du tag `tutorial-lock` (i18n),
- chaîne de fallback `{{ tag }}` quand aucun motif ne matche.

Le format de sortie reste identique (mêmes balises, mêmes classes, mêmes attributs), seule la sécurité de l'échappement change.

## Notes

- Pas de modification du contrat public du composant.
- `DOMPurify.sanitize()` reste appelé avant `links()` ; cette PR comble la fuite à la sortie. Une seconde passe DOMPurify *après* `links()` serait possible mais imposerait d'élargir `ADD_ATTR` (`depth`, `weapon`, `chip`, `potion`, `data-alias`) — gardée pour une PR séparée si souhaité.
- Aucune dépendance ajoutée.

## Tests manuels

Sur une page d'encyclopédie de dev contenant les payloads ci-dessus :

- avant la PR : exécution de `alert()` dès l'affichage de la page,
- après la PR : le HTML attaquant apparaît en texte échappé, aucun script n'est exécuté.

